### PR TITLE
Fix: show actual values in deployment limit error messages

### DIFF
--- a/errors/src/errors/cli/cli_errors.rs
+++ b/errors/src/errors/cli/cli_errors.rs
@@ -288,15 +288,15 @@ create_messages!(
 
     @backtraced
     constraint_limit_exceeded {
-        args: (program: impl Display, limit: u64, network: impl Display),
-        msg: format!("Program `{program}` exceeds the constraint limit {limit} for deployment on network {network}."),
+        args: (program: impl Display, actual: u64, limit: u64, network: impl Display),
+        msg: format!("Program `{program}` has {actual} constraints, which exceeds the limit of {limit} for deployment on network {network}."),
         help: Some("Reduce the number of constraints in the program by reducing the number of instructions in transition functions.".to_string()),
     }
 
     @backtraced
     variable_limit_exceeded {
-        args: (program: impl Display, limit: u64, network: impl Display),
-        msg: format!("Program `{program}` exceeds the variable limit {limit} for deployment on network {network}."),
+        args: (program: impl Display, actual: u64, limit: u64, network: impl Display),
+        msg: format!("Program `{program}` has {actual} variables, which exceeds the limit of {limit} for deployment on network {network}."),
         help: Some("Reduce the number of variables in the program by reducing the number of instructions in transition functions.".to_string()),
     }
 

--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -195,15 +195,9 @@ fn handle_deploy<N: Network>(
             let deployment = transaction.deployment().expect("Expected a deployment in the transaction");
             // Print the deployment stats.
             print_deployment_stats(&program_id.to_string(), deployment, priority_fee)?;
-            // Check if the number of variables and constraints are within the limits.
-            if deployment.num_combined_variables()? > N::MAX_DEPLOYMENT_VARIABLES {
-                return Err(CliError::variable_limit_exceeded(program_id, N::MAX_DEPLOYMENT_VARIABLES, network).into());
-            }
-            if deployment.num_combined_constraints()? > N::MAX_DEPLOYMENT_CONSTRAINTS {
-                return Err(
-                    CliError::constraint_limit_exceeded(program_id, N::MAX_DEPLOYMENT_CONSTRAINTS, network).into()
-                );
-            }
+
+            validate_deployment_limits(&deployment, &program_id, &network)?;
+
             // Save the transaction.
             transactions.push((program_id, transaction));
         }
@@ -330,6 +324,27 @@ fn check_tasks_for_warnings<N: Network>(
         }
     }
     warnings
+}
+
+/// Check if the number of variables and constraints are within the limits.
+fn validate_deployment_limits<N: Network>(
+    deployment: &Deployment<N>,
+    program_id: &ProgramID<N>,
+    network: &NetworkName,
+) -> Result<()> {
+    // Check if the number of variables is within the limits.
+    let combined_variables = deployment.num_combined_variables()?;
+    if combined_variables > N::MAX_DEPLOYMENT_VARIABLES {
+        Err(CliError::variable_limit_exceeded(program_id, combined_variables, N::MAX_DEPLOYMENT_VARIABLES, network))?
+    }
+
+    // Check if the number of constraints is within the limits.
+    let constraints = deployment.num_combined_constraints()?;
+    if constraints > N::MAX_DEPLOYMENT_CONSTRAINTS {
+        Err(CliError::constraint_limit_exceeded(program_id, constraints, N::MAX_DEPLOYMENT_CONSTRAINTS, network))?
+    }
+
+    Ok(())
 }
 
 /// Pretty‑print the deployment plan without using a table.

--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -335,13 +335,25 @@ fn validate_deployment_limits<N: Network>(
     // Check if the number of variables is within the limits.
     let combined_variables = deployment.num_combined_variables()?;
     if combined_variables > N::MAX_DEPLOYMENT_VARIABLES {
-        Err(CliError::variable_limit_exceeded(program_id, combined_variables, N::MAX_DEPLOYMENT_VARIABLES, network))?
+        return Err(CliError::variable_limit_exceeded(
+            program_id,
+            combined_variables,
+            N::MAX_DEPLOYMENT_VARIABLES,
+            network,
+        )
+        .into());
     }
 
     // Check if the number of constraints is within the limits.
     let constraints = deployment.num_combined_constraints()?;
     if constraints > N::MAX_DEPLOYMENT_CONSTRAINTS {
-        Err(CliError::constraint_limit_exceeded(program_id, constraints, N::MAX_DEPLOYMENT_CONSTRAINTS, network))?
+        return Err(CliError::constraint_limit_exceeded(
+            program_id,
+            constraints,
+            N::MAX_DEPLOYMENT_CONSTRAINTS,
+            network,
+        )
+        .into());
     }
 
     Ok(())


### PR DESCRIPTION
## Motivation
When my program fails to deploy due to limit constraints, I’d like to see the exact value by which it exceeded the limits.

